### PR TITLE
SelectionBox jumped when click on outside.

### DIFF
--- a/src/pygame_gui/components/listbox.py
+++ b/src/pygame_gui/components/listbox.py
@@ -40,6 +40,7 @@ class ListBox(RectContainer):
         on_relative_change: Callable[[float], None] = None
     ):
         super().__init__(w, h, x, y)
+        self.interactive_when_active = True
         self.lines = lines if lines is not None else []
         self.on_relative_change = utils.getCallable(on_relative_change)
 


### PR DESCRIPTION
Current labeling image may change even if you doesn't click selection box.

This is because the click callback mechanism. Just set `interactive_when_active` to `True` can sovle this problem.