### PR TITLE
Does not save when switch image using keyboard.

### DIFF
--- a/src/label/controller.py
+++ b/src/label/controller.py
@@ -151,6 +151,7 @@ class LabelController:
         label_path: str = None,
         relabel: bool = False
     ) -> None:
+        self.save()
         self._loadImage(image_path)
         self._loadLabels(label_path)
 

--- a/src/tasks/armor24/page.py
+++ b/src/tasks/armor24/page.py
@@ -219,8 +219,6 @@ class ArmorPage(StackedPage):
         filename: Union[str, None],
         is_deserted: bool
     ) -> None:
-        self.label_controller.save()
-
         if filename is None:
             self.label_controller.reload(None, None, False)
             self.label_controller.canvas.redraw()


### PR DESCRIPTION
A severe bug: When users use keyboard to switch between images, any modifications made to the labels are not saved.

Add save logic in `reload` function to ensures that changes are automatically saved during image switching.