### PR TITLE
Fixed MacOS compatibility issue.

### DIFF
--- a/src/pygame_gui/components/base.py
+++ b/src/pygame_gui/components/base.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple, Hashable
+from typing import Callable, Hashable, List, Tuple
 
 import pygame
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -4,8 +4,14 @@ import tkinter as tk
 from tkinter import filedialog
 from typing import Any, Tuple
 
-root = tk.Tk()
-root.withdraw()
+from .. import pygame_gui as ui
+
+try:
+    root = tk.Tk()
+    root.withdraw()
+    _has_display_device = True
+except tk.TclError:
+    _has_display_device = False
 
 class ConfigManager:
     def __init__(self, path: str):
@@ -41,8 +47,14 @@ class ConfigManager:
         return self.data[key]
 
 def openDir() -> Tuple[str, str, str]:
-    images_folder = filedialog.askdirectory(title='Images')
-    labels_folder = filedialog.askdirectory(title='Labels')
+    if _has_display_device:
+        images_folder = filedialog.askdirectory(title='Images')
+        labels_folder = filedialog.askdirectory(title='Labels')
+    else:
+        ui.logger.error(
+            'no display name and no $DISPLAY environment variable',
+            tk.TclError
+        )
     deserted_folder = os.path.join(images_folder, 'deserted')
     if not os.path.exists(deserted_folder):
         os.makedirs(deserted_folder)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -4,6 +4,8 @@ import tkinter as tk
 from tkinter import filedialog
 from typing import Any, Tuple
 
+root = tk.Tk()
+root.withdraw()
 
 class ConfigManager:
     def __init__(self, path: str):
@@ -39,9 +41,6 @@ class ConfigManager:
         return self.data[key]
 
 def openDir() -> Tuple[str, str, str]:
-    root = tk.Tk()
-    root.withdraw()
-
     images_folder = filedialog.askdirectory(title='Images')
     labels_folder = filedialog.askdirectory(title='Labels')
     deserted_folder = os.path.join(images_folder, 'deserted')


### PR DESCRIPTION
On macOS platform, clicking "Open Folder" button may throw exception:

```bash
2025-03-12 19:33:05.291 python[44969:1333447] +[IMKClient subclass]: chose IMKClient_Modern
2025-03-12 19:33:05.291 python[44969:1333447] +[IMKInputSession subclass]: chose IMKInputSession_Modern
2025-03-12 19:33:43.618 python[44969:1333447] TSM AdjustCapsLockLEDForKeyTransitionHandling - _ISSetPhysicalKeyboardCapsLockLED Inhibit
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[SDLApplication macOSVersion]: unrecognized selector sent to instance 0x158d092f0'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000018d5c2e80 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000018d0aacd8 objc_exception_throw + 88
        2   CoreFoundation                      0x000000018d6781d8 -[NSObject(NSObject) __retain_OA] + 0
        3   CoreFoundation                      0x000000018d52f830 ___forwarding___ + 1568
        4   CoreFoundation                      0x000000018d52f150 _CF_forwarding_prep_0 + 96
        5   libtk8.6.dylib                      0x0000000107a4fcbc GetRGBA + 64
        6   libtk8.6.dylib                      0x0000000107a4fab8 TkpGetColor + 448
        7   libtk8.6.dylib                      0x000000010799a794 Tk_GetColor + 168
        8   libtk8.6.dylib                      0x000000010798bd9c Tk_Get3DBorder + 152
        9   libtk8.6.dylib                      0x000000010798bc00 Tk_Alloc3DBorderFromObj + 136
        10  libtk8.6.dylib                      0x000000010799bd6c DoObjConfig + 848
        11  libtk8.6.dylib                      0x000000010799b924 Tk_InitOptions + 372
        12  libtk8.6.dylib                      0x000000010799b808 Tk_InitOptions + 88
        13  libtk8.6.dylib                      0x00000001079c8da8 CreateFrame + 1472
        14  libtk8.6.dylib                      0x00000001079c90d4 TkListCreateFrame + 172
        15  libtk8.6.dylib                      0x00000001079c1a90 Initialize + 1848
        16  _[tkinter.cpython-311-darwin.so](http://tkinter.cpython-311-darwin.so/)      0x000000010550213c Tkapp_New + 876
        17  _[tkinter.cpython-311-darwin.so](http://tkinter.cpython-311-darwin.so/)      0x0000000105501bb0 _tkinter_create + 648
        18  python3.11                          0x0000000102648e20 cfunction_vectorcall_FASTCALL + 256
        19  python3.11                          0x00000001025f0df4 PyObject_Vectorcall + 76
        20  python3.11                          0x00000001026f283c _PyEval_EvalFrameDefault + 46152
        21  python3.11                          0x00000001026f6e18 _PyEval_Vector + 184
        22  python3.11                          0x00000001025f0758 _PyObject_FastCallDictTstate + 320
        23  python3.11                          0x00000001025f15e8 _PyObject_Call_Prepend + 176
        24  python3.11                          0x000000010266c804 slot_tp_init + 196
        25  python3.11                          0x0000000102664dfc type_call + 464
        26  python3.11                          0x00000001025f04ec _PyObject_MakeTpCall + 332
        27  python3.11                          0x00000001026f283c _PyEval_EvalFrameDefault + 46152
        28  python3.11                          0x00000001026e6424 PyEval_EvalCode + 220
        29  python3.11                          0x000000010274c3f8 run_mod + 144
        30  python3.11                          0x000000010274be58 _PyRun_SimpleFileObject + 1260
        31  python3.11                          0x000000010274af18 _PyRun_AnyFileObject + 240
        32  python3.11                          0x000000010277192c Py_RunMain + 3100
        33  python3.11                          0x0000000102772784 pymain_main + 1252
        34  python3.11                          0x0000000102593684 main + 56
        35  dyld                                0x000000018d0e8274 start + 2840
)
libc++abi: terminating due to uncaught exception of type NSException
zsh: abort      python start.py
```

This exception is caused by this function:

```python
def openDir() -> Tuple[str, str, str]:
    root = tk.Tk()
    root.withdraw()

    images_folder = filedialog.askdirectory(title='Images')
    labels_folder = filedialog.askdirectory(title='Labels')
    deserted_folder = os.path.join(images_folder, 'deserted')
    if not os.path.exists(deserted_folder):
        os.makedirs(deserted_folder)
    return images_folder, labels_folder, deserted_folder
```

In macOS, `MainView` should be defined as a global variable. But in this function, `root = tk.Tk()` is defined as a local variable. To solve this issue, we just need to make it global.